### PR TITLE
ListInterview: duplicate parameter i/[INDEX] accepted and displays interviews for the last index

### DIFF
--- a/src/main/java/presspal/contact/logic/parser/ListInterviewCommandParser.java
+++ b/src/main/java/presspal/contact/logic/parser/ListInterviewCommandParser.java
@@ -27,6 +27,8 @@ public class ListInterviewCommandParser implements Parser<ListInterviewCommand> 
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListInterviewCommand.MESSAGE_USAGE));
         }
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDEX);
+
         //get the index for the person
         Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
         //return ListInterviewCommand with the index of Person

--- a/src/test/java/presspal/contact/logic/parser/ListInterviewCommandParserTest.java
+++ b/src/test/java/presspal/contact/logic/parser/ListInterviewCommandParserTest.java
@@ -9,6 +9,7 @@ import static presspal.contact.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
+import presspal.contact.logic.Messages;
 import presspal.contact.logic.commands.ListInterviewCommand;
 
 public class ListInterviewCommandParserTest {
@@ -27,6 +28,12 @@ public class ListInterviewCommandParserTest {
 
         assertParseFailure(parser, " " + PREFIX_INDEX,
                 String.format(MESSAGE_INVALID_INDEX));
+    }
+
+    @Test
+    public void parse_duplicateIndex_throwsParseException() {
+        assertParseFailure(parser, " " + PREFIX_INDEX + "1" + " " + PREFIX_INDEX + "1",
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_INDEX));
     }
 
     @Test


### PR DESCRIPTION
Fix #205 